### PR TITLE
chore(repo): migrar referências do GitLab para o GitHub

### DIFF
--- a/app-of-apps/values.yaml
+++ b/app-of-apps/values.yaml
@@ -8,7 +8,7 @@ global:
       server: https://kubernetes.default.svc
       name: default
     source:
-      repoURL: https://gitlab.com/lappis-unb/gest-odadosipea/infra-lappis-ipea.git
+      repoURL: https://github.com/GovHub-br/continuous-deployment.git
       targetRevision: HEAD
 
 argocdApplications:

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -133,15 +133,15 @@ kubectl create ns argocd
 
 ```bash
 helm -n argocd install argocd argo/argo-cd --version 6.4.1 \
-  -f https://gitlab.com/lappis-unb/gest-odadosipea/infra-lappis-ipea/-/raw/main/argocd/values.yaml \
-  -f https://gitlab.com/lappis-unb/gest-odadosipea/infra-lappis-ipea/-/raw/main/argocd/values.prod.yaml
+  -f https://raw.githubusercontent.com/GovHub-br/continuous-deployment/refs/heads/main/argocd/values.yaml \
+  -f https://raw.githubusercontent.com/GovHub-br/continuous-deployment/refs/heads/main/argocd/values.prod.yaml
 ```
 
 3. **Criar o app-of-apps (produção)**:
 
 ```bash
 kubectl -n argocd apply -f \
-  https://gitlab.com/lappis-unb/gest-odadosipea/infra-lappis-ipea/-/raw/main/argocd/application.prod.yaml
+  https://raw.githubusercontent.com/GovHub-br/continuous-deployment/refs/heads/main/argocd/application.prod.yaml
 ```
 
 > Para **atualizar**, troque `install` por `upgrade`.

--- a/argocd/application.prod.yaml
+++ b/argocd/application.prod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: "https://gitlab.com/lappis-unb/gest-odadosipea/infra-lappis-ipea.git"
+    repoURL: "https://github.com/GovHub-br/continuous-deployment.git"
     targetRevision: HEAD
     path: argocd/entrypoints/prod
   destination:

--- a/argocd/entrypoints/preprod/entrypoint.yaml
+++ b/argocd/entrypoints/preprod/entrypoint.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: "https://gitlab.com/lappis-unb/gest-odadosipea/infra-lappis-ipea.git"
+    repoURL: "https://github.com/GovHub-br/continuous-deployment.git"
     targetRevision: main
     path: app-of-apps
     helm:

--- a/argocd/entrypoints/prod/entrypoint.yaml
+++ b/argocd/entrypoints/prod/entrypoint.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: "https://gitlab.com/lappis-unb/gest-odadosipea/infra-lappis-ipea.git"
+    repoURL: "https://github.com/GovHub-br/continuous-deployment.git"
     targetRevision: main
     path: app-of-apps
     helm:

--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -58,13 +58,13 @@ Há três formas de instalação, documentadas a seguir.
 Clonar este repositório.
 
 ```bash
-git clone git@gitlab.com:lappis-unb/gest-odadosipea/infra-lappis-ipea.git
+git clone https://github.com/GovHub-br/continuous-deployment.git
 ```
 
-Navegar até a pasta 'infra-lappis-ipea/jupyterhub'.
+Navegar até a pasta 'continuous-deployment/jupyterhub'.
 
 ```bash
-cd infra-lappis-ipea
+cd continuous-deployment
 cd jupyterhub
 ```
 


### PR DESCRIPTION
- atualiza repoURL no Argo CD (Application e app-of-apps)
- ajusta .Values.global.spec.source.repoURL e refs em values.*
- atualiza READMEs/links para o novo repositório