### PR TITLE
feat(docs): adiciona template de mensagem de commit padronizada

### DIFF
--- a/.github/TEMPLATES/COMMIT_TEMPLATE.md
+++ b/.github/TEMPLATES/COMMIT_TEMPLATE.md
@@ -1,0 +1,68 @@
+# Modelo de Mensagem de Commit (Conventional Commits)
+
+Este documento serve como um guia rápido para a criação de mensagens de commit padronizadas. O uso deste formato é essencial para manter o histórico do projeto legível, facilitar a automação e gerar changelogs de forma automática.
+
+## Estrutura Principal
+
+Cada mensagem de commit consiste em um cabeçalho, um corpo opcional e um rodapé opcional. A estrutura é a seguinte:
+
+```md
+<tipo>[escopo opcional]: <descrição>
+
+[corpo opcional]
+
+[rodapé(s) opcional(is)]
+```
+
+-   **tipo**: Obrigatório. Define a categoria da mudança (ex: `feat`, `fix`, `docs`).
+-   **escopo**: Opcional. Especifica a parte do código que foi alterada (ex: `api`, `parser`, `database`).
+-   **descrição**: Obrigatório. Um resumo conciso da mudança, em letras minúsculas e sem ponto final.
+-   **corpo**: Opcional. Fornece mais contexto, explicando o "porquê" da mudança. Separado da descrição por uma linha em branco.
+-   **rodapé**: Opcional. Usado para referenciar issues (ex: `Refs: #42`) ou para declarar _breaking changes_ (ex: `BREAKING CHANGE:...`).
+
+## Tipos de Commit Recomendados
+
+| Tipo       | Descrição                                                                      |
+| :--------- | :----------------------------------------------------------------------------- |
+| `feat`     | Introduz uma nova funcionalidade ou capacidade.                                |
+| `fix`      | Corrige um bug ou erro no código.                                              |
+| `docs`     | Alterações relacionadas exclusivamente à documentação.                         |
+| `refactor` | Alterações no código que não corrigem um bug nem adicionam uma funcionalidade. |
+| `perf`     | Uma mudança de código que melhora o desempenho.                                |
+| `test`     | Adição ou correção de testes automatizados.                                    |
+| `build`    | Mudanças que afetam o sistema de build ou dependências externas.               |
+| `ci`       | Mudanças nos arquivos e scripts de configuração de Integração Contínua (CI).   |
+| `chore`    | Outras mudanças que não modificam o código-fonte ou os testes.                 |
+| `style`    | Mudanças de estilo de código que não afetam a lógica (formatação, etc.).       |
+
+### Exemplos Práticos
+
+**1. Commit de correção de bug (fix):**
+
+`fix: corrige cálculo de offset na paginação da API`
+
+**2. Commit de nova funcionalidade (feat) com escopo:**
+
+```md
+feat(parser): adiciona suporte para o formato de dados do TSE
+
+Refs: #45
+```
+
+**3. Commit com corpo para mais detalhes:**
+
+```md
+perf(database): otimiza query para busca de metadados
+
+A query anterior utilizava um JOIN desnecessário que causava lentidão
+em datasets com mais de 10.000 registros. Esta mudança simplifica
+a consulta e adiciona um índice na coluna de metadados.
+```
+
+**4. Commit que fecha uma issue do GitHub:**
+
+```md
+fix(ui): resolve problema de renderização de tabelas no Firefox
+
+Closes: #78
+```


### PR DESCRIPTION
## Issue Relacionada

Closes #8

## Descrição das Mudanças

Este PR adiciona o arquivo `COMMIT_TEMPLATE.md` ao diretório `.github/TEMPLATES/`.

O objetivo é estabelecer o padrão Conventional Commits para o repositório de dados. Isso é especialmente importante neste contexto para diferenciar claramente alterações de performance (perf) em processamento de dados, correções de bugs em parsers (fix) e novas integrações (feat).

## Como Testar

Navegue até a pasta `.github/TEMPLATES` neste branch.
Abra o arquivo `COMMIT_TEMPLATE.md` e verifique se a formatação Markdown está correta.
Confirme se os tipos de commit sugeridos são adequados para o projeto.

## Screenshots / Demos (se aplicável)

N/A (Apenas documentação)

## Checklist do Contribuidor

- [x] Meu código segue as diretrizes de estilo deste projeto.
- [x] Eu realizei uma auto-revisão do meu próprio código.
- [ ] Eu adicionei comentários ao meu código, particularmente em áreas difíceis de entender.
- [x] Eu fiz as alterações correspondentes na documentação.
- [x] Minhas alterações não geram novos avisos (warnings).
- [ ] Eu adicionei testes que provam que minha correção é eficaz ou que minha funcionalidade funciona.
- [x] Todos os testes novos e existentes passam localmente com minhas mudanças.